### PR TITLE
issue-14: submit timesheet

### DIFF
--- a/back/api/timesheet/routes.py
+++ b/back/api/timesheet/routes.py
@@ -54,7 +54,8 @@ def submit_timesheet(timesheet_id: int,
                     status_code=status.HTTP_200_OK,
                     content={"message":"Timesheet submitted sucessfully"}
                 )
-            return JSONResponse(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                content={"message": "Failed to submit timesheet, invalid timesheet ID"}
-            )
+    # If the success condition is not met, an invalid timesheet ID was provided
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        content={"message": "Failed to submit timesheet, invalid timesheet ID"}
+    )


### PR DESCRIPTION
I have created the path and implemented the method for submitting a timesheet. The timesheet updates the timesheets data entry (in the timesheet table), changing its approval status to submitted. The timesheet_id path variable is used to get the id of the timesheet data entry.

The update query when testing did not throw any errors if a non existent timesheet_id is entered. To gauge this I used the psycopg cursor to execute the query and check the rows affected by the update query. If the value was 1 the timesheet submission was a success, if the value was zero the timesheet_id value was wrong and a HTTP 400 request was returned.

Closes #14 