### PR TITLE
issue-81: Consultant: Get Submitted Holidays

### DIFF
--- a/back/api/consultant/models.py
+++ b/back/api/consultant/models.py
@@ -31,9 +31,9 @@ class ConsultantUser(BaseModel):
     manager_firstname: str
     manager_lastname: str
 
-class ConsultantTimesheet(BaseModel):
-    """Model for displaying timesheets (as an inital list on the consultant page)"""
-    timesheet_id: int
+class Entry(BaseModel):
+    """Model for displaying an entry (as an inital list on the consultant page)"""
+    entry_id: int
     created: datetime
     submitted: datetime | None
     approval_status: str


### PR DESCRIPTION
I created a general method called get_entries. The paths and functions for get timesheets and get holidays use this general method (passing in the table name to specify the type of entry). The logic of the get_entries method is the same as the previous get_timesheets method.

Since we are passing the table type on the backend I used the .format string composition to form the query. For approval status and consultant_id I used %s to pass the user input into the sql query.

Closes #81 