### PR TITLE
Issue-88: Manager: Get Assigned Consultants

### DIFF
--- a/back/api/manager/routes.py
+++ b/back/api/manager/routes.py
@@ -29,9 +29,8 @@ def get_assigned_consultants(user_id: int,
         with connection.cursor() as cursor:
             rows = cursor.execute(
                 """SELECT id FROM consultants
-                         WHERE manager_id = %s""", (manager_id,)).fetchall()
-            rows = list(sum(rows, ()))
-            consultants = cast(list[int], rows)
+                         WHERE manager_id = %s""", (user_id,)).fetchall()
+            consultants = [cast(int, row[0]) for row in rows]
     return consultants
 
 @router.get("/{user_id}/timesheets", status_code=status.HTTP_200_OK, response_model=None)


### PR DESCRIPTION
This branch is based of branch: issue-92

The path function returns a List of integers being the consultant ids of the consultants assigned to a manager specified by the manager_id

The methods don't check if the manager id's exist, since it doesn't throw errors when executing the query. In the event an incorrect manager_id is given, an empty list is returned.

Closes #88