### PR TITLE
Issue30: Manage Timesheet Modal

### DIFF
--- a/front/src/components/DashboardTable.js
+++ b/front/src/components/DashboardTable.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+
 
 const TIMESHEET = styled.table`
     width: 100%;
@@ -104,11 +105,16 @@ const OVERLAY_TEXT = styled.p`
     font-size: 18px;
 `
 
-const DashboardTable = () => {
-    const [weekDates, setWeekDates] = useState(getWeekDates());
-    const [editable, setEditable] = useState(true);   //change to true for testing 
 
-    // TODO: Make table values editable / uneditable based on the status of EditToggleButton
+
+const DashboardTable = ({submittable}) => {
+    const [weekDates, setWeekDates] = useState(getWeekDates());
+    const [editable, setEditable] = useState(false);   //change to true for testing 
+
+    useEffect(() => {
+        setEditable(submittable);
+    }, [submittable]);
+
     // Function to generate the current week dates to display on table rows
     function getWeekDates() {
         const today = new Date();

--- a/front/src/components/ManageTimesheetModal.js
+++ b/front/src/components/ManageTimesheetModal.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import ModalWrapper from './ModalWrapper';
+import DashboardTable from './DashboardTable';
+import SubmitButton from './SubmitButton';
+import styled from 'styled-components';
+
+const ModalContent = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: end
+`;
+
+function ManageTimesheetModal({overlayVisible, submittable, setOverlayVisible}) {
+
+    return (
+        <ModalWrapper isVisible={overlayVisible} toggleOverlay={() => setOverlayVisible(false)} title={'Timesheet'}>
+            <ModalContent>
+                <DashboardTable submitable={submittable} />
+                {submittable && <SubmitButton isActive={true}/>}
+            </ModalContent>
+        </ModalWrapper>
+    );
+}
+
+export default ManageTimesheetModal;

--- a/front/src/components/WeeklyHoursTable.js
+++ b/front/src/components/WeeklyHoursTable.js
@@ -101,7 +101,7 @@ const fetchedTimesheetData = [
 ];
   
 
-const DashboardTable = () => {
+const WeeklyHoursTable = () => {
     const [timesheetData, setTimesheetData] = useState(fetchedTimesheetData);
     const [overlayVisible, setOverlayVisible] = useState(false);
 
@@ -177,4 +177,4 @@ const DashboardTable = () => {
     
 }
 
-export default DashboardTable
+export default WeeklyHoursTable


### PR DESCRIPTION
The ManageTimesheetModal works. I changed the `DashboardTable.js` slightly (now a submittable variable is passed in that sets the editable value).  Renamed `WeeklyHoursTable`. **Once #22 is done, The modal should look fine.**
![image](https://github.com/timesphere-systems/timesphere/assets/118920618/c2747179-a498-455a-a9f7-76b6f8cd981f)
![image](https://github.com/timesphere-systems/timesphere/assets/118920618/d187a6f7-cabb-4c01-a3bd-02e566c4b3b9)