### PR TITLE
issue-13: Retrieve Current Timesheet Data

### DIFF
--- a/back/api/consultant/routes.py
+++ b/back/api/consultant/routes.py
@@ -339,7 +339,7 @@ def get_current_week_timesheet(consultant_id: int,
     current_timesheet = None
     with pool.connection() as connection:
         with connection.cursor(row_factory=class_row(Timesheet)) as cursor:
-            # pylint: disable-next=duplicate-code
+            # pylint: disable=duplicate-code
             current_timesheet = cursor.execute("""
                     SELECT timesheets.id as id, timesheets.created AS created,
                         timesheets.submitted AS submitted, 


### PR DESCRIPTION
I have implemented the method and path for getting the current week timesheet. 

The authorisation for this method checks if the `consultant_id` path variable value is the same as the `current_user.consultant_id` .

The method calculates the Monday date of the current week and uses that date value as well as the consultant id to find current week timesheet via an sql query. If a timesheet is found a JSON response returns the timesheet_id. If no timesheets are found then a JSON response is returned stating the current user is not assigned a timesheet for the current week.

With this implementation I wanted to confirm three things:
- the path format
- is it ok to have the back end calculate the monday start date for the current week.
- Do we want to return just the current week timesheet id (and the front end use that id to get the timesheet details) or return the details of the current week timesheet

Closes #13